### PR TITLE
Update Get-TeamsNumbers.ps1

### DIFF
--- a/Get-TeamsNumbers/Get-TeamsNumbers.ps1
+++ b/Get-TeamsNumbers/Get-TeamsNumbers.ps1
@@ -199,16 +199,10 @@ function NewLyncNumberFromAdContact {
 }
 
 Function Get-AllnumbersInDeployment{
-    # Microsoft.Rtc.Management.ADConnect.Schema.ADUser
     $userUris = Get-CsOnlineUser -Filter {LineURI -ne $Null} -WarningAction SilentlyContinue | % { NewLyncNumberFromAdContact "User" $_ }
-    #$userUris.count
-
-    # combine all results together
     $allUsedNumbers = New-Object System.Collections.ArrayList 
-    foreach($list in @($userUris,$plUris,$analogUris,$caUris,$rgsUris,$dialinUris,$exumUris,$tepUris,$MTRUris)) {
-	    if($list -and $list.Length -gt 0) {
-		    $allUsedNumbers.AddRange($list)
-	    }
+    foreach($list in @($userUris)) {
+		    $allUsedNumbers.Add($list)
     }
 
     Return $allUsedNumbers


### PR DESCRIPTION
I have been testing the script for a customer and this function didn't work. It seems that there is a problem with the if statement. The condition always evaluates to $false. I have to modify and simplify it to get it working in my lab.

I also found that the function Get-CompleteWorkingRange fails with a border condition. If $AllUSedNumbers is empty/null (there is no user with a phone number assigned), you get "Cannot index into a null array".

